### PR TITLE
Change default insertBy implementation to work better with dlists.

### DIFF
--- a/src/Data/ListLike/Base.hs
+++ b/src/Data/ListLike/Base.hs
@@ -513,10 +513,11 @@ class (IsList full, item ~ Item full, FoldableLL full item, Monoid full) =>
     {- | Like 'insert', but with a custom comparison function -}
     insertBy :: (item -> item -> Ordering) -> item ->
                 full -> full
-    insertBy cmp x ys
-        | null ys = singleton x
-        | otherwise = case cmp x (head ys) of
-                        GT -> cons (head ys) (insertBy cmp x (tail ys))
+    insertBy cmp x ys =
+        case uncons ys of
+            Nothing -> singleton x
+            Just (ys_head,ys_tail) -> case cmp x ys_head of
+                        GT -> cons ys_head (insertBy cmp x ys_tail)
                         _ ->  cons x ys
 
     ------------------------------ Generic Operations

--- a/src/Data/ListLike/DList.hs
+++ b/src/Data/ListLike/DList.hs
@@ -6,6 +6,8 @@
 
 module Data.ListLike.DList () where
 
+import qualified Prelude
+
 import Data.ListLike.Base
 import Data.ListLike.FoldableLL
 import Data.ListLike.String
@@ -20,6 +22,7 @@ import qualified Data.List as List
 import qualified Data.String as S
 import Control.Category
 import Data.Char (Char)
+
 
 instance FoldableLL (DList a) a where
   foldl = F.foldl
@@ -56,6 +59,11 @@ instance ListLike (DList a) a where
   --toList = D.toList
   --fromList = D.fromList
   replicate = D.replicate
+  uncons xs = case xs of
+    D.Nil -> Prelude.Nothing
+    D.Cons d_head l_tail -> Prelude.Just (d_head,fromList l_tail)
+    _ -> Prelude.error "Workaround for missing COMPLETE pragma on dlist patterns"
+
 
 instance StringLike (DList Char) where
   toString = D.toList


### PR DESCRIPTION
Instead of repeatedly computing head share the `head` computation.
I've also replaced `head` and `tail` by a single call to uncons for similar reasons and
replaced the default uncons implementation for DList by one based on it's pattern synonym.

