### PR TITLE
Fix deprecation warnings with bytestring-0.12

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -254,6 +254,14 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set bytestring-0.12
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='bytestring >= 0.12' all ; fi
       - name: save cache
         uses: actions/cache/save@v3
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 CHANGES
 =======
 
+#### 4.7.8.1 (2023-07-12)
+
+  - allow `bytestring-0.12` and fix its deprecation warnings
+  - tested with GHC 7.10 - 9.6
+
+### 4.7.8 (2022-11-15)
+
+  - change default `insertBy` implementation to work better with dlists
+    ([#18](https://github.com/ddssff/listlike/pull/18))
+  - allow `vector-0.13`
+  - tested with GHC 7.10 - 9.4
+
 ### 4.7.7 (2022-05-26)
 
   - methods `sequence` and `mapM`: relax `Monad` constraint to `Applicative`

--- a/ListLike.cabal
+++ b/ListLike.cabal
@@ -1,5 +1,5 @@
 Name: ListLike
-Version: 4.7.8
+Version: 4.7.8.1
 License: BSD3
 Maintainer: David Fox <dsf@seereason.com>, Andreas Abel
 Author: John Goerzen
@@ -120,4 +120,4 @@ Test-suite listlike-tests
 
 source-repository head
   type:     git
-  location: git://github.com/ddssff/listlike.git
+  location: https://github.com/ddssff/listlike.git

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,1 +1,7 @@
 branches: master
+
+constraint-set bytestring-0.12
+  ghc: >= 8.2
+  constraints: bytestring >= 0.12
+  tests: True
+  run-tests: True

--- a/src/Data/ListLike/Instances.hs
+++ b/src/Data/ListLike/Instances.hs
@@ -215,13 +215,13 @@ instance ListLike BS.ByteString Word8 where
     genericReplicate i = BS.replicate (fromIntegral i)
 
 instance ListLikeIO BS.ByteString Word8 where
-    hGetLine = BS.hGetLine
+    hGetLine = BSC.hGetLine
     hGetContents = BS.hGetContents
     hGet = BS.hGet
     hGetNonBlocking = BS.hGetNonBlocking
     hPutStr = BS.hPutStr
     hPutStrLn = BSC.hPutStrLn
-    getLine = BS.getLine
+    getLine = BSC.getLine
     getContents = BS.getContents
     putStr = BS.putStr
     putStrLn = BSC.putStrLn
@@ -345,13 +345,13 @@ instance ListLike BSL.ByteString Word8 where
 strict2lazy :: BS.ByteString -> IO BSL.ByteString
 strict2lazy b = return (BSL.fromChunks [b])
 instance ListLikeIO BSL.ByteString Word8 where
-    hGetLine h = BS.hGetLine h >>= strict2lazy
+    hGetLine h = BSC.hGetLine h >>= strict2lazy
     hGetContents = BSL.hGetContents
     hGet = BSL.hGet
     hGetNonBlocking = BSL.hGetNonBlocking
     hPutStr = BSL.hPut
     -- hPutStrLn = BSLC.hPutStrLn
-    getLine = BS.getLine >>= strict2lazy
+    getLine = BSC.getLine >>= strict2lazy
     getContents = BSL.getContents
     putStr = BSL.putStr
     putStrLn = BSLC.putStrLn

--- a/src/Data/ListLike/UTF8.hs
+++ b/src/Data/ListLike/UTF8.hs
@@ -135,7 +135,7 @@ instance ListLike (UTF8 BS.ByteString) Char where
     -- genericReplicate i = UTF8.replicate (fromIntegral i)
 
 instance ListLikeIO (UTF8 BS.ByteString) Char where
-    hGetLine h = UTF8.fromRep <$> BS.hGetLine h
+    hGetLine h = UTF8.fromRep <$> BSC.hGetLine h
     hGetContents h = UTF8.fromRep <$> BS.hGetContents h
     hGet h n = UTF8.fromRep <$> BS.hGet h n
     hGetNonBlocking h n = UTF8.fromRep <$> BS.hGetNonBlocking h n
@@ -258,7 +258,7 @@ instance ListLike (UTF8 BSL.ByteString) Char where
     -- genericReplicate i = UTF8.replicate (fromIntegral i)
 
 instance ListLikeIO (UTF8 BSL.ByteString) Char where
-    hGetLine h = (UTF8.fromRep . BSL.fromStrict) <$> BS.hGetLine h
+    hGetLine h = (UTF8.fromRep . BSL.fromStrict) <$> BSC.hGetLine h
     hGetContents h = (UTF8.fromRep) <$> BSL.hGetContents h
     hGet h n = UTF8.fromRep <$> BSL.hGet h n
     hGetNonBlocking h n = UTF8.fromRep <$> BSL.hGetNonBlocking h n


### PR DESCRIPTION
Fixes #29

Candidate: https://hackage.haskell.org/package/ListLike-4.7.8.1/candidate/changelog
