### PR TITLE
v4.7.8.3: Drop support for GHC 7, allow newer containers

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -214,6 +214,7 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package ListLike" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: containers
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(ListLike)$/; }' >> cabal.project.local
           cat cabal.project
@@ -252,6 +253,16 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set containers-0.8
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGES
 =======
 
+#### 4.7.8.3 (2025-03-13)
+
+  - drop support for GHC 7
+  - allow `containers-0.8` and up
+  - tested with GHC 8.0 - 9.12.1
+
 #### 4.7.8.2 (2023-10-10)
 
   - pacify GHC 9.8's new `x-partial` warning

--- a/ListLike.cabal
+++ b/ListLike.cabal
@@ -1,6 +1,6 @@
-Cabal-Version: >= 1.10
+Cabal-Version: 1.18
 Name: ListLike
-Version: 4.7.8.2
+Version: 4.7.8.3
 
 License: BSD3
 Maintainer: David Fox <dsf@seereason.com>, Andreas Abel
@@ -38,13 +38,12 @@ Tested-With:
   GHC == 8.2.2
   GHC == 8.0.2
 
-extra-source-files:
+extra-doc-files:
   README.md
   CHANGELOG.md
 
 Library
   default-language: Haskell2010
-  GHC-Options: -Wall
   Hs-Source-Dirs: src
   Exposed-Modules: Data.ListLike
           Data.ListLike.Base
@@ -68,16 +67,17 @@ Library
           Data.ListLike.DList
           Data.ListLike.FMList
   -- Other-Modules: Data.ConfigFile.Lexer
-  Build-Depends: base       >= 4.8   && < 5
-                ,containers >= 0.3   && < 0.8
-                ,bytestring >= 0.9.1 && < 0.13
-                ,array      >= 0.3   && < 0.6
-                ,text       >= 0.11  && < 1.3  || >= 2.0 && < 2.2
-                ,vector     >= 0.5   && < 0.14
-                ,dlist      >= 0.7   && < 1.1
-                ,fmlist     >= 0.8   && < 0.10
-                ,utf8-string >= 0.3.1 && < 1.1
-                ,deepseq
+  Build-Depends:
+      base        >= 4.9      && < 5
+    , containers  >= 0.5.7    && < 1
+    , bytestring  >= 0.10.8   && < 0.13
+    , array       >= 0.5      && < 0.6
+    , text        >= 1.2      && < 1.3  || >= 2.0 && < 2.2
+    , vector      >= 0.12     && < 0.14
+    , dlist       >= 0.8      && < 1.1
+    , fmlist      >= 0.9      && < 0.10
+    , utf8-string >= 1.0      && < 1.1
+    , deepseq
 
   -- Remark: Atm, we don't comply with the Haskell Package Versioning Policy
   --   https://pvp.haskell.org/
@@ -95,8 +95,9 @@ Library
   If !impl(ghc >= 8.4)
     Build-Depends: semigroups >= 0.16 && < 0.20
 
-  if impl(ghc >= 8.0)
-    ghc-options:  -Wcompat
+  ghc-options:
+    -Wall
+    -Wcompat
 
 Test-suite listlike-tests
   default-language: Haskell2010
@@ -105,19 +106,20 @@ Test-suite listlike-tests
   Type:           exitcode-stdio-1.0
 
   Other-modules:  TestInfrastructure
-  Build-depends:   base
-                  ,ListLike
-                  ,HUnit      >= 1.2 && < 2
-                  ,QuickCheck >= 2.4 && < 3
-                  ,random     >= 1   && < 2
-                  ,array
-                  ,bytestring
-                  ,containers
-                  ,dlist
-                  ,fmlist
-                  ,text
-                  ,vector
-                  ,utf8-string
+  Build-depends:
+      base
+    , ListLike
+    , HUnit      >= 1.5 && < 2
+    , QuickCheck >= 2.9 && < 3
+    , random     >= 1.1 && < 2
+    , array
+    , bytestring
+    , containers
+    , dlist
+    , fmlist
+    , text
+    , vector
+    , utf8-string
   If !impl(ghc >= 8.4)
     Build-Depends: semigroups >= 0.16 && < 0.20
 

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,13 +1,10 @@
 branches: master
 
--- constraint-set bytestring-0.12
---   ghc: >= 8.2
---   constraints: bytestring ^>= 0.12
---   tests: True
---   run-tests: True
---
--- constraint-set text-2.1
---   ghc: >= 8.2
---   constraints: text ^>= 2.1
---   tests: True
---   run-tests: True
+constraint-set containers-0.8
+  ghc: >= 8.2
+  constraints: containers ^>=0.8
+  tests: True
+  run-tests: True
+
+raw-project
+  allow-newer: containers

--- a/src/Data/ListLike/Chars.hs
+++ b/src/Data/ListLike/Chars.hs
@@ -7,10 +7,6 @@ module Data.ListLike.Chars
 
 where
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-import           Data.Monoid
-#endif
 import           Control.DeepSeq
 --import           Control.Monad
 import           Data.String as String (IsString)

--- a/src/Data/ListLike/DList.hs
+++ b/src/Data/ListLike/DList.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude, MultiParamTypeClasses, FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 {-# LANGUAGE CPP #-}
 
 -- | 'Data.ListLike.ListLike' instances for 'Data.DList.DList'

--- a/src/Data/ListLike/FMList.hs
+++ b/src/Data/ListLike/FMList.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, TypeFamilies #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 -- | 'Data.ListLike.ListLike' instances for 'Data.FMList.FMList'
 module Data.ListLike.FMList () where
 import Prelude hiding (cycle, map)

--- a/src/Data/ListLike/Instances.hs
+++ b/src/Data/ListLike/Instances.hs
@@ -3,9 +3,9 @@
             ,FlexibleInstances
             ,TypeFamilies
             ,TypeSynonymInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 #if __GLASGOW_HASKELL__ > 901
-{-# OPTIONS -fno-warn-incomplete-uni-patterns #-}
+{-# OPTIONS -Wno-incomplete-uni-patterns #-}
 #endif
 
 {-
@@ -539,11 +539,6 @@ instance ListLikeIO (S.Seq Char) Char where
     -- readFile
     -- writeFile
     -- appendFile
-
-#if !MIN_VERSION_containers(0,5,7)
-instance IsString (S.Seq Char) where
-  fromString = S.fromList
-#endif
 
 instance StringLike (S.Seq Char) where
     toString = toList

--- a/src/Data/ListLike/Text/Builder.hs
+++ b/src/Data/ListLike/Text/Builder.hs
@@ -2,15 +2,12 @@
             ,MultiParamTypeClasses
             ,TypeFamilies
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Text.Builder
 
 where
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import           Control.DeepSeq (NFData(rnf))
 import qualified Data.Text.Lazy.Builder as Builder
 import           Data.ListLike.Base as LL

--- a/src/Data/ListLike/Text/Text.hs
+++ b/src/Data/ListLike/Text/Text.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Text.Text
 

--- a/src/Data/ListLike/Text/TextLazy.hs
+++ b/src/Data/ListLike/Text/TextLazy.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE MultiParamTypeClasses
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Text.TextLazy
 

--- a/src/Data/ListLike/UTF8.hs
+++ b/src/Data/ListLike/UTF8.hs
@@ -4,7 +4,7 @@
             ,TypeFamilies
             ,TypeSynonymInstances
             ,UndecidableInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 {- |
 Instances of 'Data.ListLike.ListLike' and related classes.
@@ -16,9 +16,6 @@ Re-exported by "Data.ListLike".
 
 module Data.ListLike.UTF8 () where
 
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as BSL

--- a/src/Data/ListLike/Vector/Generic.hs
+++ b/src/Data/ListLike/Vector/Generic.hs
@@ -1,14 +1,12 @@
-{-# LANGUAGE CPP
-            ,MultiParamTypeClasses
-            ,FlexibleContexts
-            ,FlexibleInstances
-            ,TypeFamilies
-            ,UndecidableInstances #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeOperators #-}  -- for GHC >= 9.4
-#if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE OverlappingInstances #-}
-#endif
-{-# OPTIONS -fno-warn-orphans #-}
+
+{-# OPTIONS -Wno-orphans #-}
 
 -- | ListLike instance for any type supporting the @Data.Vector.Generic@
 -- interface.  To avoid collisions with other Vector instances, this module

--- a/src/Data/ListLike/Vector/Storable.hs
+++ b/src/Data/ListLike/Vector/Storable.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses
             ,TypeFamilies
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Vector.Storable ()
 

--- a/src/Data/ListLike/Vector/Unboxed.hs
+++ b/src/Data/ListLike/Vector/Unboxed.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses
             ,TypeFamilies
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Vector.Unboxed ()
 

--- a/src/Data/ListLike/Vector/Vector.hs
+++ b/src/Data/ListLike/Vector/Vector.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses
             ,TypeFamilies
             ,FlexibleInstances #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 module Data.ListLike.Vector.Vector ()
 

--- a/testsrc/TestInfrastructure.hs
+++ b/testsrc/TestInfrastructure.hs
@@ -8,7 +8,7 @@
             ,UndecidableInstances
             ,TypeFamilies
             ,FlexibleContexts #-}
-{-# OPTIONS -fno-warn-orphans #-}
+{-# OPTIONS -Wno-orphans #-}
 
 {-
 Copyright (C) 2007 John Goerzen <jgoerzen@complete.org>
@@ -81,18 +81,6 @@ instance (Arbitrary i) => Arbitrary (FM.FMList i) where
 
 instance (CoArbitrary i) => CoArbitrary (FM.FMList i) where
     coarbitrary l = coarbitrary (LL.toList l)
-
-#if ! MIN_VERSION_QuickCheck(2,8,2)
-instance (Arbitrary i) => Arbitrary (S.Seq i) where
-    arbitrary = sized (\n -> choose (0, n) >>= myVector)
-        where myVector n =
-                  do arblist <- vector n
-                     return (LL.fromList arblist)
-    shrink = map LL.fromList . shrink . LL.toList
-
-instance (CoArbitrary i) => CoArbitrary (S.Seq i) where
-    coarbitrary l = coarbitrary (LL.toList l)
-#endif
 
 instance Arbitrary (BSL.ByteString) where
     arbitrary = sized (\n -> choose (0, n) >>= myVector)
@@ -311,11 +299,7 @@ runVerbTestText (HU.PutText put us) test = do
     put (HU.showCounts (HU.counts ss)) False us'
   reportError   = reportProblem "Error:"   "Error in:   "
   reportFailure = reportProblem "Failure:" "Failure in: "
-#if MIN_VERSION_HUnit(1,3,0)
   reportProblem p0 p1 _mloc msg ss us' = put line True us'
-#else
-  reportProblem p0 p1 msg ss us' = put line True us'
-#endif
    where line  = "### " ++ kind ++ path' ++ '\n' : msg
          kind  = if null path' then p0 else p1
          path' = HU.showPath (HU.path ss)

--- a/testsrc/runtests.hs
+++ b/testsrc/runtests.hs
@@ -1,18 +1,17 @@
-{-# LANGUAGE CPP
-            ,TypeFamilies
-            ,ScopedTypeVariables
-            ,RankNTypes
-            ,ExistentialQuantification
-            ,MultiParamTypeClasses
-            ,FunctionalDependencies
-            ,FlexibleInstances
-            ,UndecidableInstances
-            ,FlexibleContexts #-}
-{-# OPTIONS -fno-warn-missing-signatures #-}
-
-#if __GLASGOW_HASKELL__ >= 708
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE AllowAmbiguousTypes #-}
-#endif
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS -Wno-missing-signatures #-}
+
 
 {-
 Copyright (C) 2007 John Goerzen <jgoerzen@complete.org>


### PR DESCRIPTION
We don't test GHC 7 anymore, so best to drop it.
This also allows us to lift lower bounds of the dependencies to those of LTS 9 (for GHC 8.0).
Subsequently, we can drop some conditionals.